### PR TITLE
Restored linear run-time of the z algorithm

### DIFF
--- a/Sources/atcoder-library-swift/String.swift
+++ b/Sources/atcoder-library-swift/String.swift
@@ -6,31 +6,23 @@
 //
 
 extension String {
-	
-	subscript(i: Int) -> String {
-		return String(self[index(startIndex, offsetBy: i)])
-	}
-	
 	func zAlgorithm() -> [Int] {
-		let n = self.count
-		if (n == 0) {
-			return []
-		}
-		var z = Array(repeating: 0, count: n)
-		z[0] = 0
-		var i = 1, j = 0
-		while (i < n) {
-			z[i] = (j + z[j] <= i ? 0 : min(j + z[j] - i, z[i - j]))
-			while (i + z[i] < n && self[z[i]] == self[i + z[i]]) {
-				z[i] += 1
-			}
-			if (j + z[j] < i + z[i]) {
-				j = i
-			}
-			i += 1
-		}
-		z[0] = n
-		return z
+    let chArr = Array(self)
+    let n = chArr.count
+    var z = Array(repeating: 0, count: n)
+
+    var j = 0
+    for i in 1..<n {
+      z[i] = (j + z[j] <= i ? 0 : min(j + z[j] - i, z[i - j]))
+      while (i + z[i] < n && chArr[z[i]] == chArr[i + z[i]]) {
+        z[i] += 1
+      }
+      if (j + z[j] < i + z[i]) {
+        j = i
+      }
+    }
+    z[0] = n
+    return z
 	}
 	
 }

--- a/Tests/atcoder-library-swiftTests/stringTests.swift
+++ b/Tests/atcoder-library-swiftTests/stringTests.swift
@@ -6,19 +6,20 @@
 //
 
 import XCTest
+import Foundation
+
 @testable import atcoder_library_swift
 
 final class stringTests : XCTestCase {
 	
 	private func zAlgorithmNaive(_ s: String) -> [Int] {
-		let n = s.count
-		var z = Array(repeating: 0, count: n)
-		for i in 0..<n {
-			while (i + z[i] < n && s[z[i]] == s[i + z[i]]) {
-				z[i] += 1
-			}
-		}
-		return z
+    var slice = s[...]
+    var z: [Int] = []
+    while !slice.isEmpty {
+      z.append(s.commonPrefix(with: slice).count)
+      slice = slice.dropFirst()
+    }
+    return z
 	}
 	
 	func testzAlgorithm() {


### PR DESCRIPTION
There are two changes here both related to the same issue the inefficiency of integer-based subscripting of Strings:

1: The z Algorithm was changed to first convert the string to a character array and then work over that. This restores the expected O(n) performance.
2: The naive algorithm in the tests was replaced by a "swiftier" version that uses Foundation's `commonPrefix` method. Not only is it easier to follow, but it too is faster than the integer-subscripted version.

I also removed a couple of unneeded lines of code from the z algorithm.